### PR TITLE
Update supported dependency versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,18 @@
 ---
+# When upgrading supported versions, use the following compatibility chart:
+# https://docs.djangoproject.com/en/dev/faq/install/#faq-python-version-support
+
 language: python
 python:
-  - 2.7
-  - 3.4
-  - 3.5
-  - 3.6
+  - "3.5"
+  - "3.6"
+  - "3.7"
 
 cache: pip
 
 env:
-  - DJANGO='>= 1.11, < 1.12'
-  - DJANGO='>= 2.0, < 2.1'
-
-matrix:
-  exclude:
-    # Django dropped support for Python 2 in versions 2.0 and above
-    - python: 2.7
-      env: DJANGO='>= 2.0, < 2.1'
+  - DJANGO='>= 2.1, < 2.2'
+  - DJANGO='>= 2.2, < 2.3'
 
 install:
   - pip install --upgrade pip
@@ -36,8 +32,8 @@ jobs:
     - stage: PyPI release
       if: tag IS present
 
-      python: 3.6
-      env: DJANGO='>= 2.0, < 2.1'
+      python: 3.7
+      env: DJANGO='>= 2.2, < 2.3'
 
       # Skip usual steps
       install: skip

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 #########
 
+**************
+In Development
+**************
+
+Breaking Changes:
+
+* Dropped support for Python versions before 3.5.
+* Dropped support for Django versions before 2.2.
+
 
 ******
 v0.1.1


### PR DESCRIPTION
We now support Python versions 3.6 and up as well as Django versions 2.2 and up.